### PR TITLE
Add new resource to Online Labs section

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ World class security researchers and bug bounty hunters are on Twitter. Where ar
 	 - PentesterLab: https://pentesterlab.com/referral/olaL4k8btE8wqA (premium)
 
  - **Online Labs**
+         - LabEx: https://labex.io/skilltrees/cybersecurity (premium/free)
 	 - PortSwigger Web Security Academy: https://portswigger.net/web-security
 	 - OWASP Juice Shop: https://owasp.org/www-project-juice-shop/
 	 - XSSGame: https://xss-game.appspot.com/


### PR DESCRIPTION
Add LabEx cybersecurity labs to Online Labs section.

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. Our Cybersecurity Skill Tree currently offers 34 foundational skills and 80 hands-on labs, making it perfect for beginners to learn cybersecurity step by step. 

This repo is a great resource. Please let me know if any changes are needed.